### PR TITLE
Ensure properies are arrays.

### DIFF
--- a/lib/puppet/provider/netapp_aggregate/cmode.rb
+++ b/lib/puppet/provider/netapp_aggregate/cmode.rb
@@ -155,9 +155,11 @@ Puppet::Type.type(:netapp_aggregate).provide(:cmode, :parent => Puppet::Provider
 
     # Add nodes object
     nodes = NaElement.new('nodes')
-    @resource[:nodes].each do |node|
-      node.child_add_string('node-name', node)
+    node_names = NaElement.new('node-name')
+    Array(@resource[:nodes]).each do |node|
+      node_names.child_add(NaElement.new(node))
     end unless @resource[:nodes].nil?
+    nodes.child_add(node_names)
     aggr_create.child_add(nodes)
 
     # Add the aggregate

--- a/lib/puppet/provider/netapp_cluster_peer/cmode.rb
+++ b/lib/puppet/provider/netapp_cluster_peer/cmode.rb
@@ -89,7 +89,7 @@ Puppet::Type.type(:netapp_cluster_peer).provide(:cmode, :parent => Puppet::Provi
 
       # Add peeraddress array
       peeraddresses_element = NaElement.new('peer-addresses')
-      @resource[:peeraddresses].each do |peer_address|
+      Array(@resource[:peeraddresses]).each do |peer_address|
         peeraddresses_element.child_add_string('remote-inet-address', peer_address)
       end
       peer_modify.child_add(peeraddresses_element)
@@ -116,7 +116,7 @@ Puppet::Type.type(:netapp_cluster_peer).provide(:cmode, :parent => Puppet::Provi
 
     # Add peeraddresses array
     peeraddresses_element = NaElement.new('peer-addresses')
-    @resource[:peeraddresses].each do |peer_address|
+    Array(@resource[:peeraddresses]).each do |peer_address|
       peeraddresses_element.child_add_string('remote-inet-address', peer_address)
     end
     peer_create.child_add(peeraddresses_element)

--- a/lib/puppet/provider/netapp_export_rule/cmode.rb
+++ b/lib/puppet/provider/netapp_export_rule/cmode.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:netapp_export_rule).provide(:cmode, :parent => Puppet::Provid
       rw_security = []
       rw_rules = rule.child_get('rw-rule').children_get()
       rw_rules.each do |rw_rule|
-        rw_security << rw_rule.content().to_sym
+        rw_security << rw_rule.content()
       end
       # Add it to the export_rule hash
       export_rule[:rwrule] = rw_security
@@ -143,28 +143,28 @@ Puppet::Type.type(:netapp_export_rule).provide(:cmode, :parent => Puppet::Provid
 
       # Process protocol array
       protocol_element = NaElement.new('protocol')
-      @resource[:protocol].each do |protocol|
+      Array(@resource[:protocol]).each do |protocol|
         protocol_element.child_add_string('access-protocol', protocol)
       end
       export_rule_modify.child_add(protocol_element)
 
       # Process rorule array
       rorule_element = NaElement.new('ro-rule')
-      @resource[:rorule].each do |rorule|
+      Array(@resource[:rorule]).each do |rorule|
         rorule_element.child_add_string('security-flavor', rorule)
       end unless @resource[:rorule].nil?
       export_rule_modify.child_add(rorule_element)
 
       # Process rwrule array
       rwrule_element = NaElement.new('rw-rule')
-      @resource[:rwrule].each do |rwrule|
+      Array(@resource[:rwrule]).each do |rwrule|
         rwrule_element.child_add_string('security-flavor', rwrule)
       end unless @resource[:rwrule].nil?
       export_rule_modify.child_add(rwrule_element)
 
       # Process superusersecurity array
       susecrule_element = NaElement.new('super-user-security')
-      @resource[:superusersecurity].each do |susecrule|
+      Array(@resource[:superusersecurity]).each do |susecrule|
         susecrule_element.child_add_string('security-flavor', susecrule)
       end unless @resource[:superusersecurity].nil?
       export_rule_modify.child_add(susecrule_element)
@@ -201,28 +201,28 @@ Puppet::Type.type(:netapp_export_rule).provide(:cmode, :parent => Puppet::Provid
 
     # Process protocol array
     protocol_element = NaElement.new('protocol')
-    @resource[:protocol].each do |protocol|
+    Array(@resource[:protocol]).each do |protocol|
       protocol_element.child_add_string('access-protocol', protocol)
     end
     export_rule_create.child_add(protocol_element)
 
     # Process rorule array
     rorule_element = NaElement.new('ro-rule')
-    @resource[:rorule].each do |rorule|
+    Array(@resource[:rorule]).each do |rorule|
       rorule_element.child_add_string('security-flavor', rorule)
     end unless @resource[:rorule].nil?
     export_rule_create.child_add(rorule_element)
 
     # Process rwrule array
     rwrule_element = NaElement.new('rw-rule')
-    @resource[:rwrule].each do |rwrule|
+    Array(@resource[:rwrule]).each do |rwrule|
       rwrule_element.child_add_string('security-flavor', rwrule)
     end unless @resource[:rwrule].nil?
     export_rule_create.child_add(rwrule_element)
 
     # Process superusersecurity array
     susecrule_element = NaElement.new('super-user-security')
-    @resource[:superusersecurity].each do |susecrule|
+    Array(@resource[:superusersecurity]).each do |susecrule|
       susecrule_element.child_add_string('security-flavor', susecrule)
     end unless @resource[:superusersecurity].nil?
     export_rule_create.child_add(susecrule_element)

--- a/lib/puppet/provider/netapp_ldap_client/cmode.rb
+++ b/lib/puppet/provider/netapp_ldap_client/cmode.rb
@@ -127,7 +127,7 @@ Puppet::Type.type(:netapp_ldap_client).provide(:cmode, :parent => Puppet::Provid
     # Add servers array
     unless @resource[:servers].nil?
       addresses_element = NaElement.new('servers')
-      @resource[:servers].each do |server|
+      Array(@resource[:servers]).each do |server|
         addresses_element.child_add_string('ip-address', server)
       end
       args.child_add(addresses_element)
@@ -135,7 +135,7 @@ Puppet::Type.type(:netapp_ldap_client).provide(:cmode, :parent => Puppet::Provid
     # Add preffered_servers array
     unless @resource[:preffered_ad_servers].nil?
       preffered_addresses_element = NaElement.new('preffered-ad-servers')
-      @resource[:preffered_ad_servers].each do |server|
+      Array(@resource[:preffered_ad_servers]).each do |server|
         preffered_addresses_element.child_add_string('ip-address', server)
       end
       args.child_add(preffered_addresses_element)

--- a/lib/puppet/provider/netapp_nfs_export/sevenmode.rb
+++ b/lib/puppet/provider/netapp_nfs_export/sevenmode.rb
@@ -155,12 +155,12 @@ Puppet::Type.type(:netapp_nfs_export).provide(:sevenmode, :parent => Puppet::Pro
       unless @resource[:readwrite].nil?
         readwrite = NaElement.new("read-write")
         Puppet.debug("Got a readwrite array. Checking if all_hosts... First record = #{@resource[:readwrite].first} \n")
-        if @resource[:readwrite].first == 'all_hosts'
+        if Array(@resource[:readwrite]).first == 'all_hosts'
           hostname_info = NaElement.new("exports-hostname-info")
           hostname_info.child_add_string("all-hosts", "true")
           readwrite.child_add(hostname_info)
         else
-          @resource[:readwrite].each do |host|
+          Array(@resource[:readwrite]).each do |host|
             hostname_info = NaElement.new("exports-hostname-info")
             hostname_info.child_add_string("name", host)
             readwrite.child_add(hostname_info)
@@ -172,12 +172,12 @@ Puppet::Type.type(:netapp_nfs_export).provide(:sevenmode, :parent => Puppet::Pro
       unless @resource[:readonly].nil?
         readonly = NaElement.new("read-only")
         Puppet.debug("Got a readonly array. Checking if all_hosts... First record = #{@resource[:readonly].first} \n")
-        if @resource[:readonly].first == 'all_hosts'
+        if Array(@resource[:readonly]).first == 'all_hosts'
           hostname_info = NaElement.new("exports-hostname-info")
           hostname_info.child_add_string("all-hosts", "true")
           readonly.child_add(hostname_info)
         else
-          @resource[:readonly].each do |host|
+          Array(@resource[:readonly]).each do |host|
             hostname_info = NaElement.new("exports-hostname-info")
             hostname_info.child_add_string("name", host)
             readonly.child_add(hostname_info)
@@ -219,12 +219,12 @@ Puppet::Type.type(:netapp_nfs_export).provide(:sevenmode, :parent => Puppet::Pro
     # Read-write
     unless @resource[:readwrite].nil?
       readwrite = NaElement.new("read-write")
-      if @resource[:readwrite].first == 'all_hosts'
+      if Array(@resource[:readwrite]).first == 'all_hosts'
         hostname_info = NaElement.new("exports-hostname-info")
         hostname_info.child_add_string("all-hosts", "true")
         readwrite.child_add(hostname_info)
       else
-        @resource[:readwrite].each do |host|
+        Array(@resource[:readwrite]).each do |host|
           hostname_info = NaElement.new("exports-hostname-info")
           hostname_info.child_add_string("name", host)
           readwrite.child_add(hostname_info)
@@ -236,12 +236,12 @@ Puppet::Type.type(:netapp_nfs_export).provide(:sevenmode, :parent => Puppet::Pro
     unless @resource[:readonly].nil?
       readonly = NaElement.new("read-only")
       Puppet.debug("Got a readonly array. Checking if all_hosts... First record = #{@resource[:readonly].first} \n")
-      if @resource[:readonly].first == 'all_hosts'
+      if Array(@resource[:readonly]).first == 'all_hosts'
         hostname_info = NaElement.new("exports-hostname-info")
         hostname_info.child_add_string("all-hosts", "true")
         readonly.child_add(hostname_info)
       else
-        @resource[:readonly].each do |host|
+        Array(@resource[:readonly]).each do |host|
           hostname_info = NaElement.new("exports-hostname-info")
           hostname_info.child_add_string("name", host)
           readonly.child_add(hostname_info)

--- a/lib/puppet/provider/netapp_vserver/cmode.rb
+++ b/lib/puppet/provider/netapp_vserver/cmode.rb
@@ -148,7 +148,7 @@ Puppet::Type.type(:netapp_vserver).provide(:cmode, :parent => Puppet::Provider::
       if !@resource[:namemappingswitch].nil?
         nms_element = NaElement.new("name-mapping-switch")
 
-        @resource[:namemappingswitch].each do |value|
+        Array(@resource[:namemappingswitch]).each do |value|
           nms_element.child_add_string("nmswitch", value)
         end
         vserver_modify.child_add(nms_element)
@@ -158,7 +158,7 @@ Puppet::Type.type(:netapp_vserver).provide(:cmode, :parent => Puppet::Provider::
       if !@resource[:nameserverswitch].nil?
         nss_element = NaElement.new("name-server-switch")
 
-        @resource[:nameserverswitch].each do |value|
+        Array(@resource[:nameserverswitch]).each do |value|
           nss_element.child_add_string("nsswitch", value)
         end
         vserver_modify.child_add(nss_element)
@@ -168,7 +168,7 @@ Puppet::Type.type(:netapp_vserver).provide(:cmode, :parent => Puppet::Provider::
       if !@resource[:aggregatelist].nil?
         aggrlist_element = NaElement.new("aggr-list")
 
-        @resource[:aggregatelist].each do |value|
+        Array(@resource[:aggregatelist]).each do |value|
           aggrlist_element.child_add_string("aggr-name", value)
         end
         vserver_modify.child_add(aggrlist_element)
@@ -178,7 +178,7 @@ Puppet::Type.type(:netapp_vserver).provide(:cmode, :parent => Puppet::Provider::
       if !@resource[:allowedprotos].nil?
         allowedprotos_element = NaElement.new('allowed-protocols')
 
-        @resource[:allowedprotos].each do |value|
+        Array(@resource[:allowedprotos]).each do |value|
           allowedprotos_element.child_add_string('protocol', value)
         end
         vserver_modify.child_add(allowedprotos_element)
@@ -245,7 +245,7 @@ Puppet::Type.type(:netapp_vserver).provide(:cmode, :parent => Puppet::Provider::
     if !@resource[:namemappingswitch].nil?
       nms_element = NaElement.new("name-mapping-switch")
 
-      @resource[:namemappingswitch].each do |value|
+      Array(@resource[:namemappingswitch]).each do |value|
         nms_element.child_add_string("nmswitch", value)
       end
       vserver_create.child_add(nms_element)
@@ -255,7 +255,7 @@ Puppet::Type.type(:netapp_vserver).provide(:cmode, :parent => Puppet::Provider::
     if !@resource[:nameserverswitch].nil?
       nss_element = NaElement.new("name-server-switch")
 
-      @resource[:nameserverswitch].each do |value|
+      Array(@resource[:nameserverswitch]).each do |value|
         nss_element.child_add_string("nsswitch", value)
       end
       vserver_create.child_add(nss_element)
@@ -265,7 +265,7 @@ Puppet::Type.type(:netapp_vserver).provide(:cmode, :parent => Puppet::Provider::
     # if !@resource[:aggregatelist].nil?
     #   aggrlist_element = NaElement.new("aggr-list")
 
-    #   @resource[:aggregatelist].each do |value|
+    #   Array(@resource[:aggregatelist]).each do |value|
     #     aggrlist_element.child_add_string("aggr-name", value)
     #   end
     #   vserver_create.child_add(aggrlist_element)


### PR DESCRIPTION
Puppet 3 has a behavior that when attributes which accept arrays receive
a string or a single-element array, they cast it to a string. So this
code should handle strings, nil, and arrays of strings.

In puppet 4 attribute that accept arrays are always arrays, as they should be.