### PR TITLE
Add ASUP tracking to Puppet module for NetApp Data ONTAP

### DIFF
--- a/lib/puppet/util/network_device/netapp/device.rb
+++ b/lib/puppet/util/network_device/netapp/device.rb
@@ -57,6 +57,21 @@ class Puppet::Util::NetworkDevice::Netapp::Device
       end
     end
 
+    # report existence of Puppet to ASUP service
+    ems_log = NaElement.new('ems-autosupport-log')
+
+    # Start adding values
+    ems_log.child_add_string('computer-name', Facter.value(:fqdn))
+    ems_log.child_add_string('event-id', '0')
+    ems_log.child_add_string('event-source', 'Puppet::Device::NetApp')
+    ems_log.child_add_string('app-version', Facter.value(:puppetversion))
+    ems_log.child_add_string('category', 'provisioning')
+    ems_log.child_add_string('event-description', "Puppet module managing #{redacted_url}")
+    ems_log.child_add_string('log-level', '6')
+    ems_log.child_add_string('auto-support', 'false')
+
+    Puppet.debug("Puppet::Device::Netapp: Adding usage log to EMS service")
+    @transport.invoke_elem(ems_log)
   end
 
   def facts


### PR DESCRIPTION
This adds the submission of a EMS log message to the Data ONTAP
filer being managed by Puppet. This allows NetApp to track
adoption patterns across its install base. Note that if ASUP
bundle submissions are disabled on your Data ONTAP system, this
log message will never be submitted to NetApp.