### PR TITLE
Fix export_rule for policies

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -405,8 +405,7 @@ Change ownership mode. Defaults to 'restricted'.
 Valid values are `restricted`, `unrestricted`.
 
 ##### `name`
-
-The export policy. Composite name based on policy name and rule index. Must take the form of `policy_name:rule_number` where the rule number is an integer and the policy name is an existing export policy.
+The export policy name and index. Must take the form of `policy_name:rule_number` where the rule number is an integer and the policy name is an existing export policy.
 
 ##### `ntfsunixsecops`
 

--- a/lib/puppet/provider/netapp_export_rule/cmode.rb
+++ b/lib/puppet/provider/netapp_export_rule/cmode.rb
@@ -26,10 +26,9 @@ Puppet::Type.type(:netapp_export_rule).provide(:cmode, :parent => Puppet::Provid
       Puppet.debug("Puppet::Provider::Netapp_export.cmode.prefetch: Processing rule for export #{name}. \n")
 
       # Construct an export hash for rule
-      export_rule = { :name   => name,
-                      :ensure => :present }
+      export_rule = { :ensure => :present }
 
-      export_rule[:rule_index] = rule.child_get_int("rule-index")
+      export_rule[:name] = "#{name}:#{rule.child_get_int("rule-index")}"
       # Add the anon UID if present.
       export_rule[:anonuid] = rule.child_get_string("anonymous-user-id") unless rule.child_get_string("anonymous-user-id").nil?
       # Add the client match string if present.
@@ -110,12 +109,7 @@ Puppet::Type.type(:netapp_export_rule).provide(:cmode, :parent => Puppet::Provid
     # Check required resource state
     Puppet.debug("Property_hash ensure = #{@property_hash[:ensure]}")
 
-    policy_name = @resource[:name]
-    if @resource[:rule_index]
-      rule_index = @resource[:rule_index]
-    else
-      rule_index = @original_values[:rule_index]
-    end
+    policy_name, rule_index = @resource[:name].split(':')
 
     Puppet.debug("Puppet::Provider::Netapp_export.cmode: Flushing for rule index #{rule_index} on Policy #{policy_name}")
 
@@ -196,10 +190,9 @@ Puppet::Type.type(:netapp_export_rule).provide(:cmode, :parent => Puppet::Provid
     export_rule_create.child_add_string("export-ntfs-unix-security-ops", @resource[:ntfsunixsecops])
     export_rule_create.child_add_string("is-allow-dev-is-enabled", @resource[:allowdevenabled])
     export_rule_create.child_add_string("is-allow-set-uid-enabled", @resource[:allowsetuid])
-    export_rule_create.child_add_string("policy-name", @resource[:name])
-    unless @resource[:rule_index].nil?
-      export_rule_create.child_add_string("rule-index", @resource[:rule_index])
-    end
+    policy_name, rule_index = @resource[:name].split(":")
+    export_rule_create.child_add_string("policy-name", policy_name)
+    export_rule_create.child_add_string("rule-index", rule_index)
 
     # Process protocol array
     protocol_element = NaElement.new('protocol')

--- a/lib/puppet/type/netapp_export_rule.rb
+++ b/lib/puppet/type/netapp_export_rule.rb
@@ -8,12 +8,9 @@ Puppet::Type.newtype(:netapp_export_rule) do
   ensurable
 
   newparam(:name) do
-    desc "The export policy name."
+    desc "The export policy name and index. Must take the form of `policy_name:rule_number` where the rule number is an integer and the policy name is an existing export policy."
     isnamevar
-  end
-
-  newproperty(:rule_index) do
-    desc "The rule index."
+    newvalues(/:\d+$/)
   end
 
   newproperty(:anonuid) do
@@ -162,14 +159,8 @@ Puppet::Type.newtype(:netapp_export_rule) do
     raise ArgumentError, "clientmatch is required" if ! self[:clientmatch] and ! self.provider.clientmatch
   end
 
-  # # Autorequire any matching netapp_volume resources.
-  # autorequire(:netapp_volume) do
-  #   requires = []
-  #   [self[:name], self[:path]].compact.each do |path|
-  #     if match = %r{/\w+/(\w+)(?:/\w+)?$}.match(path)
-  #       requires << match.captures[0]
-  #     end
-  #   end
-  #   requires
-  # end
+  # Autorequire any matching netapp_export_policy
+  autorequire(:netapp_export_policy) do
+    [self[:name].split(":").first]
+  end
 end

--- a/spec/acceptance/netapp_export_rule_spec.rb
+++ b/spec/acceptance/netapp_export_rule_spec.rb
@@ -8,10 +8,18 @@ node 'vsim-01' {
 node 'vserver-01' {
   netapp_export_policy { 'export_rule_test' :
     ensure => present,
-  } 
-  netapp_export_rule { 'export_rule_test' :
+  }
+  netapp_export_rule { 'export_rule_test:1' :
     ensure            => present,
     clientmatch       => '10.0.0.0/8',
+    protocol          => ['nfs'],
+    superusersecurity => 'none',
+    rorule            => ['none', 'sys'],
+    rwrule            => ['none', 'sys'],
+  }
+  netapp_export_rule { 'export_rule_test:2' :
+    ensure            => present,
+    clientmatch       => '192.168.0.0/16',
     protocol          => ['nfs'],
     superusersecurity => 'none',
     rorule            => ['none', 'sys'],
@@ -31,14 +39,12 @@ node 'vsim-01' {
 node 'vserver-01' {
   netapp_export_policy { 'export_rule_test' :
     ensure => absent,
-  } 
-  netapp_export_rule { 'export_rule_test' :
+  }
+  netapp_export_rule { 'export_rule_test:1' :
     ensure            => absent,
-    clientmatch       => '10.0.0.0/8',
-    protocol          => ['nfs'],
-    superusersecurity => 'none',
-    rorule            => ['sys', 'none'],
-    rwrule            => ['sys', 'none'],
+  }
+  netapp_export_rule { 'export_rule_test:2' :
+    ensure            => absent,
   }
 }
     EOS


### PR DESCRIPTION
export_rule resources reference an export_policy resource, but need
something to make them unique otherwise only one rule per policy can be
created. The readme apparently thought that the rule_index was part of
the title but the types didn't reflect this.

Also, make sure rules are applied after policies by autorequire