### PR TITLE
fix system-name match when host = fqdn and add feature to manage cluster-mgmt interfaces

### DIFF
--- a/lib/puppet/provider/netapp_aggregate/cmode.rb
+++ b/lib/puppet/provider/netapp_aggregate/cmode.rb
@@ -60,13 +60,13 @@ Puppet::Type.type(:netapp_aggregate).provide(:cmode, :parent => Puppet::Provider
       options_info = aggrgetoption('aggregate', aggregate_name)
       options = options_info.child_get('options').children_get()
       options.each do |option|
-        option_name = option.child_get_string ("name")
+        option_name = option.child_get_string("name")
         if ["free_space_realloc", "fs_size_fixed", "ha_policy", "ignore_inconsistent", "lost_write_protect", 
             "max_write_alloc_blocks", "striping", "nosnap", "raid_cv", "raid_lost_write", "raid_zoned",
             "raidsize", "cache_raid_group_size", "raidtype", "resyncsnaptime", "root", "snapmirrored", 
             "snapshot_autodelete", "thorough_scrub", "percent_snapshot_space", "nearly_full_threshold",
             "full_threshold", "is_flash_pool_caching_enabled", "hybrid_enabled", "hybrid_enabled_force"].include?(option_name)
-          aggr_info["option_#{option_name}".to_sym] = option.child_get_string ("value")
+          aggr_info["option_#{option_name}".to_sym] = option.child_get_string("value")
         end
       end
       aggregates << new(aggr_info)

--- a/lib/puppet/util/network_device/netapp/facts.rb
+++ b/lib/puppet/util/network_device/netapp/facts.rb
@@ -117,10 +117,20 @@ class Puppet::Util::NetworkDevice::Netapp::Facts
         Puppet.debug("Interfaces Result = #{iresult.inspect}")
 
         interfaces = iresult.child_get("attributes-list")
-        system_host = interfaces.children_get().find do |interface|
-          Puppet.debug("Network Address = #{interface.child_get_string('address')}, role = #{interface.child_get_string('role')}")
-          Puppet.debug("Match = #{Socket.getaddrinfo(host, nil)[0][3] == interface.child_get_string('address') ? :True : :False }")
-          Socket.getaddrinfo(host, nil)[0][3] == interface.child_get_string('address') && interface.child_get_string('role') == "cluster_mgmt"
+        interface_host = interfaces.children_get().find do |interface|
+          Puppet.debug("Network Address = #{interface.child_get_string("address")}, role = #{interface.child_get_string("role")}")
+          Puppet.debug("Match = #{Socket.getaddrinfo(host, nil)[0][3] == interface.child_get_string("address") ? :True : :False }")
+          Socket.getaddrinfo(host, nil)[0][3] == interface.child_get_string("address") && interface.child_get_string("role") == "cluster_mgmt"
+        end
+
+        if interface_host
+            Puppet.debug("Mgmt interface mached. Getting current-node value to continue")
+            # Looping node system-info again to match current-node
+            system_host = systems.children_get().find do |system|
+                Puppet.debug("System name = #{system.child_get_string("system-name").downcase}, current-node = #{interface_host.child_get_string("current-node")}")
+                Puppet.debug("Match = #{system.child_get_string("system-name").downcase == interface_host.child_get_string("current-node")}")
+                system.child_get_string("system-name").downcase == interface_host.child_get_string("current-node")
+            end
         end
       end
 

--- a/lib/puppet/util/network_device/netapp/facts.rb
+++ b/lib/puppet/util/network_device/netapp/facts.rb
@@ -104,8 +104,8 @@ class Puppet::Util::NetworkDevice::Netapp::Facts
       system_host = systems.children_get().find do |system|
         # Check the system name matches the host we're looking for
         Puppet.debug("System-name = #{system.child_get_string('system-name')}. downcase = #{system.child_get_string("system-name").downcase}")
-        Puppet.debug("Match = #{host.downcase == system.child_get_string("system-name").downcase}")
-        host.downcase == system.child_get_string("system-name").downcase
+        Puppet.debug("Match = #{host.downcase =~ /#{system.child_get_string("system-name").downcase}/ ? :True : :False }")
+        host.downcase =~ /#{system.child_get_string("system-name").downcase}/
       end
 
       if system_host


### PR DESCRIPTION
Hi,

NetApp OnTAP doesn't support node names with "." making impossible to match system-name with device name when using FQDN.

Debug:
```
Debug: System-name = cdot01node-1a. downcase = cdot01node-1a
Debug: Match = False
Error: Could not retrieve local facts: No matching system found with the system name cdot01node-1a.dc.example.com
```

```
cdot01::> node rename -node cdot01node-1a -newname cdot01node-1a.dc.example.com
Error: command failed: Invalid character "." in node name at position 13. Expected: A-Z, a-z, 0-9, "-" or "_".
       The node name "cdot01node-1a.dc.example.com" is invalid.
```

The commit d65026a fix that using regex to match system-name with FQDN.

I've also added a new feature to support manage the cluster using cluster-mgmt interfaces instead of one node direct. 
After match all the system-name I've included a new loop to match the hostname/ip address given with all the network address with role = cluster-mgmt configured. 
If one node fail or you need remove one node of the cluster you won't need change anything in the manifest/device.conf to keep puppet working.

Debug with the commit 956a8fc and 8ce54ad: 
```
Debug: System-name = cdot01node-1a. downcase = cdot01node-1a
Debug: Match = False
Debug: System-name = cdot01node-1b. downcase = cdot01node-1b
Debug: Match = False
Debug: No matching system found with the system name = cdot01-mgmt.dc.example.com. Checking if it's a cluster-mgmt interface
Debug: Interfaces Result = ...
Debug: Network Address = 10.20.1.11, role = node
Debug: Match = False
Debug: Network Address = 10.20.1.50, role = cluster_mgmt
Debug: Match = True
Debug: Mgmt interface mached. Getting current-node value to continue
Debug: System name = cdot01node-1a, current-node = cdot01node-11
Debug: Match = false
Debug: System name = cdot01node-1b, current-node = cdot01node-1b
Debug: Match = true
Debug: System info = ...
```