### PR TITLE
Changing 'else' to 'elsif' to accomdate Cluster name

### DIFF
--- a/lib/puppet/provider/netapp.rb
+++ b/lib/puppet/provider/netapp.rb
@@ -4,6 +4,7 @@ require 'puppet/util/network_device/netapp/device'
 class Puppet::Provider::Netapp < Puppet::Provider
 
   attr_accessor :device
+  LUN_RESIZE_ERROR_CODE = 9042 
   def self.transport
     if Facter.value(:url) then
       Puppet.debug "Puppet::Util::NetworkDevice::Netapp: connecting via facter url."
@@ -49,7 +50,10 @@ class Puppet::Provider::Netapp < Puppet::Provider
               result = transport.invoke(apicommand, *args)
             end
             if result.results_status == 'failed'
-              raise Puppet::Error, "Executing api call #{[apicommand, args].flatten.join(' ')} failed: #{result.results_reason.inspect}"
+              error = result.results_errno
+              if error != LUN_RESIZE_ERROR_CODE.to_s
+                raise Puppet::Error, "Executing api call #{[apicommand, args].flatten.join(' ')} failed: #{result.results_reason.inspect}"
+              end
             end
           end
 

--- a/lib/puppet/provider/netapp_lun/cmode.rb
+++ b/lib/puppet/provider/netapp_lun/cmode.rb
@@ -93,12 +93,12 @@ Puppet::Type.type(:netapp_lun).provide(:cmode, :parent => Puppet::Provider::Neta
     else
       force = @resource[:force]
     end
-
     # Resize the volume
     result = lunresize('force', force, 'path', @resource[:path], 'size', @resource[:size])
-
-    Puppet.debug("Puppet::Provider::Netapp_lun.cmode size=: Lun has been resized.")
-    return true
+    if result.results_status() != "failed"
+      Puppet.debug("Puppet::Provider::Netapp_lun.cmode size=: Lun has been resized.")
+      return true
+    end
   end
 
   # Set lun state

--- a/lib/puppet/util/network_device/netapp/facts.rb
+++ b/lib/puppet/util/network_device/netapp/facts.rb
@@ -117,6 +117,8 @@ class Puppet::Util::NetworkDevice::Netapp::Facts
         host.downcase == system.child_get_string("system-name").downcase
       end
 
+      Puppet.debug("Cluster_Name = #{cluster_name}")
+      Puppet.debug("Host Name = #{host}")
       if system_host
         # Pull out the required variables
         [
@@ -138,8 +140,9 @@ class Puppet::Util::NetworkDevice::Netapp::Facts
 
         # Facts dump
         Puppet.debug("System info = #{@facts.inspect}")
-      else
+      elsif cluster_name.downcase != host.downcase
         raise ArgumentError, "No matching system found with the system name #{host}"
+        end
       end
 
       # Get DNS domainname for fqdn


### PR DESCRIPTION
If the cluster name is used to connect to the cDOT system by specifying it in device.conf.

The if condition fails at line 120, and resulting in "No matching system found with name ...'  