### PR TITLE
Corrected bug in netapp_itterate function and added properties on netapp_snapmirror type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1167,6 +1167,12 @@ The source location.
 ##### `source_snapshot`
 The source snapshot name
 
+##### `snapmirror_policy`
+Specifies the name of the snapmirror policy for the relationship. For SnapMirror relationships of type 'vault' or 'extended data protection', the policy will also have rules to select snapshot copies that must be transferred. If no policy is specified, a default policy will be applied depending on the type of the SnapMirror relationship. This parameter is only available on Data ONTAP 8.2 or later operating in Cluster-Mode if the relationship control plane is 'v2'.
+
+##### `snapmirror_schedule`
+Specifies the name of the cron schedule, which is used to update the SnapMirror relationship.
+
 ### netapp_snapmirror_schedule
 Manage Netapp Snapmirror schedule creation, modification and deletion.
 

--- a/lib/puppet/provider/netapp.rb
+++ b/lib/puppet/provider/netapp.rb
@@ -81,7 +81,7 @@ class Puppet::Provider::Netapp < Puppet::Provider
     while !tag.nil?
       # Invoke api request
       Puppet.debug("Invoking: [#{api.inspect}, \"tag\", #{tag.inspect}]")
-      output = transport.invoke(api, "tag", tag)
+      output = transport.invoke(api, "max-records",1,"tag", tag)
       if output.results_status == 'failed'
         raise Puppet::Error, "Executing api call #{[api,"tag",tag].flatten.join(' ')} failed: #{output.results_reason.inspect}"
       end
@@ -90,15 +90,13 @@ class Puppet::Provider::Netapp < Puppet::Provider
       records_returned = output.child_get_int("num-records")
       if records_returned == 0
         Puppet.debug("No records returned on this call...")
-        return
+      else
+        # Get the result_element and push into results array
+        element = output.child_get(result_element)
+        results.push(*element.children_get())
       end
-
       # Update tag
       tag = output.child_get_string("next-tag")
-
-      # Get the result_element and push into results array
-      element = output.child_get(result_element)
-      results.push(*element.children_get())
     end
 
     # We're done itterating

--- a/lib/puppet/provider/netapp_snapmirror/cmode.rb
+++ b/lib/puppet/provider/netapp_snapmirror/cmode.rb
@@ -24,11 +24,13 @@ Puppet::Type.type(:netapp_snapmirror).provide(:cmode, :parent => Puppet::Provide
     results = snapmirrorlist() || []
     results.each do |snapmirror|
       snapmirror_hash = {
-        :name              => snapmirror.child_get_string('destination-location'),
-        :source_location   => snapmirror.child_get_string('source-location'),
-        :max_transfer_rate => snapmirror.child_get_string('max-transfer-rate'),
-        :relationship_type => snapmirror.child_get_string('relationship-type'),
-        :ensure            => :present,
+        :name                => snapmirror.child_get_string('destination-location'),
+        :source_location     => snapmirror.child_get_string('source-location'),
+        :max_transfer_rate   => snapmirror.child_get_string('max-transfer-rate'),
+        :relationship_type   => snapmirror.child_get_string('relationship-type'),
+        :snapmirror_policy   => snapmirror.child_get_string('policy'),
+        :snapmirror_schedule => snapmirror.child_get_string('schedule'),
+        :ensure              => :present,
       }
       snapmirrors << new(snapmirror_hash)
     end
@@ -66,14 +68,20 @@ Puppet::Type.type(:netapp_snapmirror).provide(:cmode, :parent => Puppet::Provide
   end
 
   def get_args (method)
+    # Parameters supported by snapmirror-create,snapmirror-modify and snapmirror-initialize APIs
     args = NaElement.new("snapmirror-#{method}")
     args.child_add_string('destination-location', @resource[:name])
     args.child_add_string('source-location', @resource[:source_location]) unless @resource[:source_location].nil?
+    args.child_add_string('max-transfer-rate', @resource[:max_transfer_rate]) unless @resource[:max_transfer_rate].nil?
     if method != 'initialize'
-      args.child_add_string('relationship-type', @resource[:relationship_type]) unless @resource[:relationship_type].nil?
-      args.child_add_string('max-transfer-rate', @resource[:max_transfer_rate]) unless @resource[:max_transfer_rate].nil?
+        # Parameters not supported by snapmirror-initialize API
+        args.child_add_string('policy', @resource[:snapmirror_policy]) unless @resource[:snapmirror_policy].nil?
+        args.child_add_string('schedule', @resource[:snapmirror_schedule]) unless @resource[:snapmirror_schedule].nil?
+        if method != 'modify'
+                # Parameter not supported by snapmirror-modify and snapmirror-initialize APIs
+                args.child_add_string('relationship-type', @resource[:relationship_type]) unless @resource[:relationship_type].nil?
+        end
     end
-
     args
   end
 end

--- a/lib/puppet/type/netapp_snapmirror.rb
+++ b/lib/puppet/type/netapp_snapmirror.rb
@@ -48,4 +48,12 @@ restore ,
 transition_data_protection ,
 extended_data_protection"
   end
+
+  newproperty(:snapmirror_policy) do
+    desc "Specifies the name of the snapmirror policy for the relationship. For SnapMirror relationships of type 'vault' or 'extended data protection', the policy will also have rules to select snapshot copies that must be transferred. If no policy is specified, a default policy will be applied depending on the type of the SnapMirror relationship. This parameter is only available on Data ONTAP 8.2 or later operating in Cluster-Mode if the relationship control plane is 'v2'."
+  end
+
+  newproperty(:snapmirror_schedule) do
+    desc "Specifies the name of the cron schedule, which is used to update the SnapMirror relationship."
+  end
 end

--- a/spec/acceptance/netapp_snapmirror_spec.rb
+++ b/spec/acceptance/netapp_snapmirror_spec.rb
@@ -46,9 +46,11 @@ node 'vsim-01' {
     peer_cluster => 'VSIM',
   }
   netapp_snapmirror { 'vs4:vs4_root':
-    ensure            => 'present',
-    relationship_type => 'data_protection',
-    source_location   => 'vs0:vs0_root',
+    ensure              => 'present',
+    relationship_type   => 'data_protection',
+    source_location     => 'vs0:vs0_root',
+    snapmirror_policy   => 'DPDefault',
+    snapmirror_schedule => 'daily',
   }
 }
 node 'vserver-01' {


### PR DESCRIPTION
On a SVM with 331 snapmirror relations I have noticed that netapp_itterate function did not return all relations but only first 16 elements. The problem was the default limit of max-records on *-get-iter calls and the while construct based on "next-tag".
Identical problem for volume-get-iter call.

Using snapmirror on ClusterDOT context, we need to define snapmirror policies and schedule to governate snapshot naming policies and retention, and schedule.

`lib/puppet/provider/netapp.rb`
- Fixed bug on netapp_itterate (fetching only first 16 elements due to max_records default of ontapi calls *get-iter)

```
lib/puppet/provider/netapp_snapmirror/cmode.rb
lib/puppet/type/netapp_snapmirror.rb
```
- Added properties snapmirror_policy and snapmirror_schedule for cmode provider.
