### PR TITLE
Manage qtree names as '/volume/qtreename' instead of just 'qtreename' #77

### DIFF
--- a/lib/puppet/provider/netapp_qtree/cmode.rb
+++ b/lib/puppet/provider/netapp_qtree/cmode.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:netapp_qtree).provide(:cmode, :parent => Puppet::Provider::Ne
       secstyle = qtree_info.child_get_string("security-style")
 
       # Construct an export hash for rule
-      qtree_hash = { :qtname          => name,
+      qtree_hash = { :qtname        => name,
                      :mode          => mode,
                      :securitystyle => secstyle,
                      :ensure        => :present }
@@ -47,8 +47,10 @@ Puppet::Type.type(:netapp_qtree).provide(:cmode, :parent => Puppet::Provider::Ne
       # Add the volume details and title
       if qtree_info.child_get_string("volume").empty?
         qtree_hash[:volume] = ""
+        qtree_hash[:name] = qtree_hash[:qtname]
       else
         qtree_hash[:volume] = qtree_info.child_get_string("volume")
+        qtree_hash[:name] = "/#{qtree_hash[:volume]}/#{qtree_hash[:qtname]}"
       end
 
       Puppet.debug("Puppet::Provider::Netapp_qtree.cmode.prefetch: Volume for '#{name}' is '#{qtree_info.child_get_string("volume")}'.")

--- a/lib/puppet/provider/netapp_qtree/cmode.rb
+++ b/lib/puppet/provider/netapp_qtree/cmode.rb
@@ -72,40 +72,40 @@ Puppet::Type.type(:netapp_qtree).provide(:cmode, :parent => Puppet::Provider::Ne
   end
 
   def flush
-    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: Got to flush for resource #{@resource[:name]}.")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: Got to flush for resource #{@resource[:qtname]}.")
 
     # Check required resource state
     Puppet.debug("Property_hash ensure = #{@property_hash[:ensure]}")
     if @property_hash[:ensure] == :absent
 
       Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: Ensure is absent.")
-      Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: destroying Netapp Qtree #{@resource[:name]} against volume #{@resource[:volume]}")
+      Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: destroying Netapp Qtree #{@resource[:qtname]} against volume #{@resource[:volume]}")
 
       # Query Netapp to remove qtree against volume.
-      result = qdel('qtree', "/vol/#{@resource[:volume]}/#{@resource[:name]}")
+      result = qdel('qtree', "/vol/#{@resource[:volume]}/#{@resource[:qtname]}")
 
-      Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: qtree #{@resource[:name]} destroyed successfully. \n")
+      Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: qtree #{@resource[:qtname]} destroyed successfully. \n")
 
     end
   end
 
   def create
-    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: creating Netapp Qtree #{@resource[:name]} on volume #{@resource[:volume]}.")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: creating Netapp Qtree #{@resource[:qtname]} on volume #{@resource[:volume]}.")
 
     # Query Netapp to create qtree against volume. .
-    result = qadd('qtree', @resource[:name], 'volume', @resource[:volume])
+    result = qadd('qtree', @resource[:qtname], 'volume', @resource[:volume])
 
-    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: Qtree #{@resource[:name]} created successfully on volume #{@resource[:volume]}. \n")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: Qtree #{@resource[:qtname]} created successfully on volume #{@resource[:volume]}. \n")
 
   end
 
   def destroy
-    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: destroying Netapp Qtree #{@resource[:name]} against volume #{@resource[:volume]}")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: destroying Netapp Qtree #{@resource[:qtname]} against volume #{@resource[:volume]}")
     @property_hash[:ensure] = :absent
   end
 
   def exists?
-    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: checking existance of Netapp qtree #{@resource[:name]} against volume #{@resource[:volume]}")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: checking existance of Netapp qtree #{@resource[:qtname]} against volume #{@resource[:volume]}")
     Puppet.debug("Value = #{@property_hash[:ensure]}")
     @property_hash[:ensure] == :present
   end

--- a/lib/puppet/provider/netapp_qtree/cmode.rb
+++ b/lib/puppet/provider/netapp_qtree/cmode.rb
@@ -39,17 +39,16 @@ Puppet::Type.type(:netapp_qtree).provide(:cmode, :parent => Puppet::Provider::Ne
       secstyle = qtree_info.child_get_string("security-style")
 
       # Construct an export hash for rule
-      qtree_hash = { :qtname        => name,
+      qtree_hash = { :qtname          => name,
                      :mode          => mode,
                      :securitystyle => secstyle,
                      :ensure        => :present }
 
       # Add the volume details and title
       if qtree_info.child_get_string("volume").empty?
-        qtree_hash[:name] = qtree_hash[:qtname]
+        qtree_hash[:volume] = ""
       else
         qtree_hash[:volume] = qtree_info.child_get_string("volume")
-        qtree_hash[:name] = "/#{qtree_hash[:volume]}/#{qtree_hash[:qtname]}"
       end
 
       Puppet.debug("Puppet::Provider::Netapp_qtree.cmode.prefetch: Volume for '#{name}' is '#{qtree_info.child_get_string("volume")}'.")
@@ -69,14 +68,19 @@ Puppet::Type.type(:netapp_qtree).provide(:cmode, :parent => Puppet::Provider::Ne
   def self.prefetch(resources)
     Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: Got to self.prefetch.")
     # Itterate instances and match provider where relevant.
-    instances.each do |prov|
-      Puppet.debug("Prov.name = #{resources[prov.name]}. ")
-      if resource = resources[prov.name]
-        resource.provider = prov
+    qtrees_list=instances
+    resources.each do |name, res|
+      Puppet.debug("name = #{name}. ")
+      Puppet.debug("Res.name = #{res[:name]}. ")
+      Puppet.debug("Res.qtname = #{res[:qtname]}. ")
+      Puppet.debug("Res.volume = #{res[:volume]}. ")
+      if provider = qtrees_list.find{ |app| app.qtname == res[:qtname] && app.volume == res[:volume] }
+        resources[name].provider = provider
       end
+      
     end
   end
-
+  
   def flush
     Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: Got to flush for resource #{@resource[:qtname]}.")
 

--- a/lib/puppet/provider/netapp_qtree/cmode.rb
+++ b/lib/puppet/provider/netapp_qtree/cmode.rb
@@ -39,13 +39,19 @@ Puppet::Type.type(:netapp_qtree).provide(:cmode, :parent => Puppet::Provider::Ne
       secstyle = qtree_info.child_get_string("security-style")
 
       # Construct an export hash for rule
-      qtree_hash = { :name          => name,
+      qtree_hash = { :qtname        => name,
                      :mode          => mode,
                      :securitystyle => secstyle,
                      :ensure        => :present }
 
-      # Add the volume details
-      qtree_hash[:volume] = qtree_info.child_get_string("volume") unless qtree_info.child_get_string("volume").empty?
+      # Add the volume details and title
+      if qtree_info.child_get_string("volume").empty?
+        qtree_hash[:name] = qtree_hash[:qtname]
+      else
+        qtree_hash[:volume] = qtree_info.child_get_string("volume")
+        qtree_hash[:name] = "/#{qtree_hash[:volume]}/#{qtree_hash[:qtname]}"
+      end
+
       Puppet.debug("Puppet::Provider::Netapp_qtree.cmode.prefetch: Volume for '#{name}' is '#{qtree_info.child_get_string("volume")}'.")
 
       # Create the instance and add to exports array.

--- a/lib/puppet/provider/netapp_qtree/cmode.rb
+++ b/lib/puppet/provider/netapp_qtree/cmode.rb
@@ -45,13 +45,8 @@ Puppet::Type.type(:netapp_qtree).provide(:cmode, :parent => Puppet::Provider::Ne
                      :ensure        => :present }
 
       # Add the volume details and title
-      if qtree_info.child_get_string("volume").empty?
-        qtree_hash[:volume] = ""
-        qtree_hash[:name] = qtree_hash[:qtname]
-      else
-        qtree_hash[:volume] = qtree_info.child_get_string("volume")
-        qtree_hash[:name] = "/#{qtree_hash[:volume]}/#{qtree_hash[:qtname]}"
-      end
+      qtree_hash[:volume] = qtree_info.child_get_string("volume")
+      qtree_hash[:name] = "/#{qtree_hash[:volume]}/#{qtree_hash[:qtname]}"
 
       Puppet.debug("Puppet::Provider::Netapp_qtree.cmode.prefetch: Volume for '#{name}' is '#{qtree_info.child_get_string("volume")}'.")
 

--- a/lib/puppet/provider/netapp_qtree/sevenmode.rb
+++ b/lib/puppet/provider/netapp_qtree/sevenmode.rb
@@ -69,40 +69,40 @@ Puppet::Type.type(:netapp_qtree).provide(:sevenmode, :parent => Puppet::Provider
   end
 
   def flush
-    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: Got to flush for resource #{@resource[:name]}.")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: Got to flush for resource #{@resource[:qtname]}.")
 
     # Check required resource state
     Puppet.debug("Property_hash ensure = #{@property_hash[:ensure]}")
     if @property_hash[:ensure] == :absent
 
       Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: Ensure is absent.")
-      Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: destroying Netapp Qtree #{@resource[:name]} against volume #{@resource[:volume]}")
+      Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: destroying Netapp Qtree #{@resource[:qtname]} against volume #{@resource[:volume]}")
 
       # Query Netapp to remove qtree against volume.
-      result = qdel('qtree', "/vol/#{@resource[:volume]}/#{@resource[:name]}")
+      result = qdel('qtree', "/vol/#{@resource[:volume]}/#{@resource[:qtname]}")
 
-      Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: qtree #{@resource[:name]} destroyed successfully. \n")
+      Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: qtree #{@resource[:qtname]} destroyed successfully. \n")
 
     end
   end
 
   def create
-    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: creating Netapp Qtree #{@resource[:name]} on volume #{@resource[:volume]}.")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: creating Netapp Qtree #{@resource[:qtname]} on volume #{@resource[:volume]}.")
 
     # Query Netapp to create qtree against volume. .
-    result = qadd('qtree', @resource[:name], 'volume', @resource[:volume])
+    result = qadd('qtree', @resource[:qtname], 'volume', @resource[:volume])
 
-    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: Qtree #{@resource[:name]} created successfully on volume #{@resource[:volume]}. \n")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: Qtree #{@resource[:qtname]} created successfully on volume #{@resource[:volume]}. \n")
 
   end
 
   def destroy
-    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: destroying Netapp Qtree #{@resource[:name]} against volume #{@resource[:volume]}")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: destroying Netapp Qtree #{@resource[:qtname]} against volume #{@resource[:volume]}")
     @property_hash[:ensure] = :absent
   end
 
   def exists?
-    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: checking existance of Netapp qtree #{@resource[:name]} against volume #{@resource[:volume]}")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: checking existance of Netapp qtree #{@resource[:qtname]} against volume #{@resource[:volume]}")
     Puppet.debug("Value = #{@property_hash[:ensure]}")
     @property_hash[:ensure] == :present
   end

--- a/lib/puppet/provider/netapp_qtree/sevenmode.rb
+++ b/lib/puppet/provider/netapp_qtree/sevenmode.rb
@@ -38,11 +38,13 @@ Puppet::Type.type(:netapp_qtree).provide(:sevenmode, :parent => Puppet::Provider
       Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode.prefetch: Processing rule for qtree '#{name}'.")
 
       # Construct an export hash for rule
-      qtree_hash = { :name => name,
+      qtree_hash = { :qtname => name,
                      :ensure => :present }
 
       # Add the volume details
-      qtree_hash[:volume] = qtree_info.child_get_string("volume") unless qtree_info.child_get_string("volume").empty?
+      qtree_hash[:volume] = qtree_info.child_get_string("volume")
+      qtree_hash[:name] = "/#{qtree_hash[:volume]}/#{qtree_hash[:qtname]}"
+
       Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode.prefetch: Volume for '#{name}' is '#{qtree_info.child_get_string("volume")}'.")
 
       # Create the instance and add to exports array.
@@ -58,15 +60,20 @@ Puppet::Type.type(:netapp_qtree).provide(:sevenmode, :parent => Puppet::Provider
   end
 
   def self.prefetch(resources)
-    Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: Got to self.prefetch.")
+    Puppet.debug("Puppet::Provider::Netapp_qtree.cmode: Got to self.prefetch.")
     # Itterate instances and match provider where relevant.
-    instances.each do |prov|
-      Puppet.debug("Prov.name = #{resources[prov.name]}. ")
-      if resource = resources[prov.name]
-        resource.provider = prov
+    qtrees_list=instances
+    resources.each do |name, res|
+      Puppet.debug("name = #{name}. ")
+      Puppet.debug("Res.name = #{res[:name]}. ")
+      Puppet.debug("Res.qtname = #{res[:qtname]}. ")
+      Puppet.debug("Res.volume = #{res[:volume]}. ")
+      if provider = qtrees_list.find{ |app| app.qtname == res[:qtname] && app.volume == res[:volume] }
+        resources[name].provider = provider
       end
     end
   end
+
 
   def flush
     Puppet.debug("Puppet::Provider::Netapp_qtree.sevenmode: Got to flush for resource #{@resource[:qtname]}.")

--- a/lib/puppet/type/netapp_qtree.rb
+++ b/lib/puppet/type/netapp_qtree.rb
@@ -11,7 +11,7 @@ Puppet::Type.newtype(:netapp_qtree) do
     isnamevar
     desc "The qtree name."
     validate do |value|
-      unless (value =~ /^[\w\-]+$/) or (value =~ /^\/\w+\/\w+$/)
+      unless (value =~ /^[\w\-\.]+$/) or (value =~ /^\/\w+\/[\w\-\.]+$/)
          raise ArgumentError, "%s is not a valid qtree name." % value
       end
     end
@@ -43,7 +43,7 @@ Puppet::Type.newtype(:netapp_qtree) do
       end
     end
     validate do |value|
-      unless value =~ /^[\w\-]+$/
+      unless value =~ /^[\w\-\.]+$/
          raise ArgumentError, "%s is not a valid qtname name." % value
       end
     end

--- a/lib/puppet/type/netapp_qtree.rb
+++ b/lib/puppet/type/netapp_qtree.rb
@@ -7,38 +7,45 @@ Puppet::Type.newtype(:netapp_qtree) do
 
   ensurable
 
-  def self.title_patterns
-    [
-      [
-        %r{^([^/].+)$},
-        [
-          [:qtname],
-        ]
-      ],
-      [
-        %r{^/([^/]+)/(.+)$},
-        [
-          [:volume],
-          [:qtname],
-        ]
-      ]
-    ]
-  end
-
-  newparam(:qtname, :namevar => true) do
-    desc "The qtname to create."
+  newparam(:name) do
+    desc "The qtree name."
     validate do |value|
-      unless value =~ /^[\w\-\.]+$/
+      unless (value =~ /^[\w\-]+$/) or (value =~ /^\/\w+\/\w+$/)
          raise ArgumentError, "%s is not a valid qtree name." % value
       end
     end
   end
 
-  newparam(:volume, :namevar => true) do
+  newproperty(:volume) do
+    isnamevar
     desc "The volume to create qtree against."
+    defaultto do
+      if @resource[:name].count('/') == 2
+        @resource[:name].split('/')[1]
+      else
+        ""
+      end
+    end
     validate do |value|
       unless value =~ /^\w+$/
          raise ArgumentError, "%s is not a valid volume name." % value
+      end
+    end
+  end
+
+  newproperty(:qtname) do
+    isnamevar
+    desc "The qtname to create."
+    defaultto do
+      if @resource[:name].count('/') == 2
+        @resource[:name].split('/')[2]
+      else
+        @resource[:name]
+      end
+    end
+    validate do |value|
+      unless value =~ /^[\w\-]+$/
+         raise ArgumentError, "%s is not a valid qtname name." % value
       end
     end
   end

--- a/lib/puppet/type/netapp_qtree.rb
+++ b/lib/puppet/type/netapp_qtree.rb
@@ -8,10 +8,10 @@ Puppet::Type.newtype(:netapp_qtree) do
   ensurable
 
   newparam(:name) do
-    desc "The qtree name."
     isnamevar
+    desc "The qtree name."
     validate do |value|
-      unless value =~ /^[\w\-]+$/
+      unless (value =~ /^[\w\-]+$/) or (value =~ /^\/\w+\/\w+$/)
          raise ArgumentError, "%s is not a valid qtree name." % value
       end
     end
@@ -19,10 +19,41 @@ Puppet::Type.newtype(:netapp_qtree) do
 
   newparam(:volume) do
     desc "The volume to create qtree against."
+    defaultto do
+      if @resource[:name].count('/') == 2
+        @resource[:name].split('/')[1] 
+      else
+        ""
+      end
+    end
     validate do |value|
       unless value =~ /^\w+$/
          raise ArgumentError, "%s is not a valid volume name." % value
       end
+    end
+  end
+  
+  newparam(:qtname) do
+    desc "The qtname to create."
+    defaultto do
+      if @resource[:name].count('/') == 2
+        @resource[:name].split('/')[2] 
+      else 
+	@resource[:name]
+      end
+    end
+    validate do |value|
+      unless value =~ /^[\w\-]+$/
+         raise ArgumentError, "%s is not a valid qtname name." % value
+      end
+    end
+  end
+
+  def qtreepart(newvalue, position)
+    if newvalue.count('/') == 2
+      return newvalue.split('/')[position] 
+    else
+      return newvalue
     end
   end
 

--- a/lib/puppet/type/netapp_qtree.rb
+++ b/lib/puppet/type/netapp_qtree.rb
@@ -7,53 +7,39 @@ Puppet::Type.newtype(:netapp_qtree) do
 
   ensurable
 
-  newparam(:name) do
-    isnamevar
-    desc "The qtree name."
+  def self.title_patterns
+    [
+      [
+        %r{^([^/].+)$},
+        [
+          [:qtname],
+        ]
+      ],
+      [
+        %r{^/([^/]+)/(.+)$},
+        [
+          [:volume],
+          [:qtname],
+        ]
+      ]
+    ]
+  end
+
+  newparam(:qtname, :namevar => true) do
+    desc "The qtname to create."
     validate do |value|
-      unless (value =~ /^[\w\-\.]+$/) or (value =~ /^\/\w+\/[\w\-\.]+$/)
+      unless value =~ /^[\w\-\.]+$/
          raise ArgumentError, "%s is not a valid qtree name." % value
       end
     end
   end
 
-  newparam(:volume) do
+  newparam(:volume, :namevar => true) do
     desc "The volume to create qtree against."
-    defaultto do
-      if @resource[:name].count('/') == 2
-        @resource[:name].split('/')[1] 
-      else
-        ""
-      end
-    end
     validate do |value|
       unless value =~ /^\w+$/
          raise ArgumentError, "%s is not a valid volume name." % value
       end
-    end
-  end
-  
-  newparam(:qtname) do
-    desc "The qtname to create."
-    defaultto do
-      if @resource[:name].count('/') == 2
-        @resource[:name].split('/')[2] 
-      else 
-	@resource[:name]
-      end
-    end
-    validate do |value|
-      unless value =~ /^[\w\-\.]+$/
-         raise ArgumentError, "%s is not a valid qtname name." % value
-      end
-    end
-  end
-
-  def qtreepart(newvalue, position)
-    if newvalue.count('/') == 2
-      return newvalue.split('/')[position] 
-    else
-      return newvalue
     end
   end
 

--- a/spec/fixtures/modules/netapp
+++ b/spec/fixtures/modules/netapp
@@ -1,0 +1,1 @@
+/home/local/Q8INT/fduranti/git/puppet-repo/puppetlabs-netapp

--- a/spec/fixtures/modules/netapp
+++ b/spec/fixtures/modules/netapp
@@ -1,1 +1,0 @@
-/home/local/Q8INT/fduranti/git/puppet-repo/puppetlabs-netapp

--- a/spec/integration/puppet/provider/netapp_quota/netapp_quota_spec.rb
+++ b/spec/integration/puppet/provider/netapp_quota/netapp_quota_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'puppet/util/network_device/netapp/NaServer'
+#require 'puppet/util/network_device/netapp/NaServer'
 
 describe Puppet::Type.type(:netapp_quota).provider(:netapp_quota), '(integration)' do
   before :each do

--- a/spec/unit/puppet/provider/netapp_group/sevenmode_spec.rb
+++ b/spec/unit/puppet/provider/netapp_group/sevenmode_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'puppet/util/network_device/netapp/NaServer'
+#require 'puppet/util/network_device/netapp/NaServer'
 
 describe Puppet::Type.type(:netapp_group).provider(:sevenmode) do
 

--- a/spec/unit/puppet/provider/netapp_nfs_export/sevenmode_spec.rb
+++ b/spec/unit/puppet/provider/netapp_nfs_export/sevenmode_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'puppet/util/network_device/netapp/NaServer'
+#require 'puppet/util/network_device/netapp/NaServer'
 
 describe Puppet::Type.type(:netapp_nfs_export).provider(:sevenmode) do
 

--- a/spec/unit/puppet/provider/netapp_qtree/sevenmode_spec.rb
+++ b/spec/unit/puppet/provider/netapp_qtree/sevenmode_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'puppet/util/network_device/netapp/NaServer'
+#require 'puppet/util/network_device/netapp/NaServer'
 
 describe Puppet::Type.type(:netapp_qtree).provider(:sevenmode) do
 
@@ -13,7 +13,7 @@ describe Puppet::Type.type(:netapp_qtree).provider(:sevenmode) do
 
   let :volume_qtree do
     Puppet::Type.type(:netapp_qtree).new(
-      :name     => 'qtree',
+      :title    => 'qtree',
       :ensure   => :present,
       :volume   => 'volume',
       :provider => provider
@@ -22,7 +22,7 @@ describe Puppet::Type.type(:netapp_qtree).provider(:sevenmode) do
 
   let :provider do
     described_class.new(
-      :name => 'qtree'
+      :title => 'qtree'
     )
   end
 
@@ -33,13 +33,13 @@ describe Puppet::Type.type(:netapp_qtree).provider(:sevenmode) do
       instances.size.should == 1
       instances.map do |prov|
         {
-          :name          => prov.get(:name),
+          :title         => prov.get(:name),
           :ensure        => prov.get(:ensure),
           :volume        => prov.get(:volume)
         }
       end.should == [
         {
-          :name          => 'qtree',
+          :title         => 'qtree',
           :ensure        => :present,
           :volume        => 'volume'
         }
@@ -76,7 +76,7 @@ describe Puppet::Type.type(:netapp_qtree).provider(:sevenmode) do
   describe "when destroying a resource" do
     it "should be able to destroy a qtree" do
       # if we destroy a provider, we must have been present before so we must have values in @property_hash
-      volume_qtree.provider.set(:name => 'qtree', :volume => 'volume')
+      volume_qtree.provider.set(:title => 'qtree', :volume => 'volume')
       volume_qtree.provider.expects(:qdel).with('qtree', "/vol/volume/qtree")
       volume_qtree.provider.destroy
       volume_qtree.provider.flush

--- a/spec/unit/puppet/provider/netapp_quota/sevenmode_spec.rb
+++ b/spec/unit/puppet/provider/netapp_quota/sevenmode_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'puppet/util/network_device/netapp/NaServer'
+#require 'puppet/util/network_device/netapp/NaServer'
 
 describe Puppet::Type.type(:netapp_quota).provider(:sevenmode) do
 
@@ -343,8 +343,6 @@ describe Puppet::Type.type(:netapp_quota).provider(:sevenmode) do
           let(:parameters) do
             user_quota_parameters
           end
-    require 'pry'
-    binding.pry
           it "should pass \"-\" as a value for #{apiproperty} if desired value is absent" do
             resource.provider.set(:name => 'bob', :type => :user, :qtree => 'qtree01', :volume => 'vol01')
             resource.provider.expects(:mod).with('quota-target', 'bob', 'quota-type', 'user', 'volume', 'vol01', 'qtree', 'qtree01', apiproperty, '-')

--- a/spec/unit/puppet/provider/netapp_role/sevenmode_spec.rb
+++ b/spec/unit/puppet/provider/netapp_role/sevenmode_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'puppet/util/network_device/netapp/NaServer'
+#require 'puppet/util/network_device/netapp/NaServer'
 
 describe Puppet::Type.type(:netapp_role).provider(:sevenmode) do
 

--- a/spec/unit/puppet/provider/netapp_user/sevenmode_spec.rb
+++ b/spec/unit/puppet/provider/netapp_user/sevenmode_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'puppet/util/network_device/netapp/NaServer'
+#require 'puppet/util/network_device/netapp/NaServer'
 
 describe Puppet::Type.type(:netapp_user).provider(:sevenmode) do
 

--- a/spec/unit/puppet/provider/netapp_volume/sevenmode_spec.rb
+++ b/spec/unit/puppet/provider/netapp_volume/sevenmode_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'yaml'
-require 'puppet/util/network_device/netapp/NaServer'
+#require 'puppet/util/network_device/netapp/NaServer'
 
 describe Puppet::Type.type(:netapp_volume).provider(:sevenmode) do
 

--- a/spec/unit/puppet/type/netapp_qtree_spec.rb
+++ b/spec/unit/puppet/type/netapp_qtree_spec.rb
@@ -34,6 +34,10 @@ describe Puppet::Type.type(:netapp_qtree) do
         described_class.new(:name => 'qtree01a', :ensure => :present)[:name].should == 'qtree01a'
       end
 
+      it "should support a volume and directory name" do
+        expect { described_class.new(:name => '/volume/dir1', :ensure => :present)[:name].should == '/volume/dir1'
+      end
+
       it "should not support a nested directory" do
         expect { described_class.new(:name => 'dir1/dir2', :ensure => :present) }.to raise_error(Puppet::Error, /dir1\/dir2 is not a valid qtree name/)
       end
@@ -74,6 +78,27 @@ describe Puppet::Type.type(:netapp_qtree) do
         expect { described_class.new(:name => 'q1', :volume => 'vol 1', :ensure => :present) }.to raise_error(Puppet::Error, /vol 1 is not a valid volume name/)
       end
     end
+    
+    describe "foo qtname" do
+      it "should support an alphanumerical name" do
+        described_class.new(:qtname => 'qtree01a', :ensure => :present)[:qtname].should == 'qtree01a'
+      end
+
+      it "should not support a nested directory" do
+        expect { described_class.new(:qtname => 'dir1/dir2', :ensure => :present) }.to raise_error(Puppet::Error, /dir1\/dir2 is not a valid qtree name/)
+      end
+
+      it "should support underscores" do
+        described_class.new(:qtname => 'foo_bar', :ensure => :present)[:qtname].should == 'foo_bar'
+      end
+
+      it "should support hyphens" do
+        described_class.new(:qtname => 'abc-def', :ensure => :present)[:qtname].should == 'abc-def'
+      end
+
+      it "should not support spaces" do
+        expect { described_class.new(:qtname => 'qtree 1', :ensure => :present) }.to raise_error(Puppet::Error, /qtree 1 is not a valid qtree name/)
+      end
   end
 
   describe "autorequiring" do


### PR DESCRIPTION
Changed property "name" so it can be "/volume/qtreename" as qtree are unique at volume level not at SVM level. Refet to #77 
* The old behaviour with still work (calling with name/volume).
* New behaviour will be used passing a "/volume/qtreename" or using property "volume" and property "qtname".
* Changed property "volume" to default to volume name is it's specified in the "name" property.
* Added a new property "qtname" that will default to the qtree name specified in the "name" property (or the * "name" property itself for the hold behaviour).
* Used "qtname" instead of "name" in the qtree management functions.
* Added tests for netapp_qtree type.