### PR TITLE
Fix allowedprotos array

### DIFF
--- a/lib/puppet/type/netapp_vserver.rb
+++ b/lib/puppet/type/netapp_vserver.rb
@@ -137,7 +137,7 @@ Puppet::Type.newtype(:netapp_vserver) do
 
   newproperty(:allowedprotos, :array_matching => :all) do
     desc "Vserver allowed protocols"
-    newvalues(:nfs, :cifs, :fcp, :iscsi, :ndmp)
+    newvalues(:nfs, :cifs, :fcp, :iscsi, :ndmpd)
 
     def insync?(is)
       # Check that the arrays are same length

--- a/lib/puppet/type/netapp_vserver.rb
+++ b/lib/puppet/type/netapp_vserver.rb
@@ -137,7 +137,7 @@ Puppet::Type.newtype(:netapp_vserver) do
 
   newproperty(:allowedprotos, :array_matching => :all) do
     desc "Vserver allowed protocols"
-    newvalues(:nfs, :cifs, :fcp, :iscsi, :ndmpd)
+    newvalues(:nfs, :cifs, :fcp, :iscsi, :ndmp)
 
     def insync?(is)
       # Check that the arrays are same length

--- a/lib/puppet/util/network_device/netapp/facts.rb
+++ b/lib/puppet/util/network_device/netapp/facts.rb
@@ -54,9 +54,19 @@ class Puppet::Util::NetworkDevice::Netapp::Facts
     # Set operatingsystem details if present
     if @facts['version'] then
       if @facts['version'] =~ /^NetApp Release (\d.\d(.\d)?\w*)/i
+        # Legacy facts
         @facts['operatingsystem'] = 'OnTAP'
-        @facts['os']['family'] = 'NetApp'
         @facts['operatingsystemrelease'] = $1
+        # New style facts
+        @facts['os'] = {}
+        @facts['os']['architecture'] = 'x86_64'
+        @facts['os']['family'] = 'OnTAP'
+        @facts['os']['hardware'] = 'x86_64'
+        @facts['os']['name'] = 'OnTAP'
+        @facts['os']['release'] = {}
+        @facts['os']['release']['full'] = $1
+        @facts['os']['release']['major'] = $1.split('.').first
+        @facts['os']['release']['minor'] = $1.split('.').last
       end
     end
 


### PR DESCRIPTION
Verified in 8.3.2 and 9.1: the protocol is called ndmp instead of ndmpd

Change-Id: I238c6b17fa31335403983d42c751fc48522f4fca