### PR TITLE
Add new style OS fact

### DIFF
--- a/lib/puppet/util/network_device/netapp/facts.rb
+++ b/lib/puppet/util/network_device/netapp/facts.rb
@@ -54,9 +54,19 @@ class Puppet::Util::NetworkDevice::Netapp::Facts
     # Set operatingsystem details if present
     if @facts['version'] then
       if @facts['version'] =~ /^NetApp Release (\d.\d(.\d)?\w*)/i
-        @facts['operatingsystem'] = 'OnTAP'
-        @facts['os']['family'] = 'NetApp'
+        # Legacy facts
+        @facts['operatingsystem'] = 'ONTAP'
         @facts['operatingsystemrelease'] = $1
+        # New style facts
+        @facts['os'] = {}
+        @facts['os']['architecture'] = 'x86_64'
+        @facts['os']['family'] = 'NetApp'
+        @facts['os']['hardware'] = 'x86_64'
+        @facts['os']['name'] = 'ONTAP'
+        @facts['os']['release'] = {}
+        @facts['os']['release']['full'] = $1
+        @facts['os']['release']['major'] = $1.split('.').first
+        @facts['os']['release']['minor'] = $1.split('.').last
       end
     end
 

--- a/spec/unit/puppet/util/network_device/netapp/facts_spec.rb
+++ b/spec/unit/puppet/util/network_device/netapp/facts_spec.rb
@@ -116,7 +116,7 @@ describe Puppet::Util::NetworkDevice::Netapp::Facts do
       :productname            => 'FAS3240',
       :manufacturer           => 'NetApp',
       :osfamily               => 'NetApp',
-      :operatingsystem        => 'OnTAP',
+      :operatingsystem        => 'ONTAP',
       :operatingsystemrelease => '8.1P2',
       :hostname               => 'filer01',
       :fqdn                   => 'filer01.example.com',


### PR DESCRIPTION
Tested with facter 3.6.7. This code only added OS related facts
that are considered legacy with newer versions of facter.
This commit adds a new style OS fact.

Change-Id: I5c8ea4cdb085dcdabd1c7c3f398e494068750c49