### PR TITLE
Fixed bug to unmount a volume.

### DIFF
--- a/lib/puppet/provider/netapp_volume/cmode.rb
+++ b/lib/puppet/provider/netapp_volume/cmode.rb
@@ -153,7 +153,7 @@ Puppet::Type.type(:netapp_volume).provide(:cmode, :parent => Puppet::Provider::N
       if jp = vol_id_info.child_get("junction-path")
         vol_junction_path = jp.content
       else
-        vol_junction_path = false
+        vol_junction_path = :false
       end
       # Check if autosize is set
       #if (vol_auto_size =~ /^grow/)
@@ -228,7 +228,7 @@ Puppet::Type.type(:netapp_volume).provide(:cmode, :parent => Puppet::Provider::N
 
   # Volume junction-path setter
   def junctionpath=(value)
-    if ! value
+    if value == :false
       result = volunmount("volume-name", @resource[:name])
     else
       result = volmount("volume-name", @resource[:name], "junction-path", value)

--- a/lib/puppet/type/netapp_volume.rb
+++ b/lib/puppet/type/netapp_volume.rb
@@ -75,7 +75,7 @@ Puppet::Type.newtype(:netapp_volume) do
     munge do |value|
       case value
       when false, :false, "false"
-        false
+        :false
       else
         value
       end


### PR DESCRIPTION
Puppet issue: https://github.com/puppetlabs/puppetlabs-netapp/issues/109

Volume was not getting unmounted though "junctionpath" property was
set as false.
Fixed by changing false value to ruby symbol at all places.