### PR TITLE
Fixed bug to fetch autosize property correctly in self instance.

### DIFF
--- a/lib/puppet/provider/netapp_volume/cmode.rb
+++ b/lib/puppet/provider/netapp_volume/cmode.rb
@@ -145,7 +145,7 @@ Puppet::Type.type(:netapp_volume).provide(:cmode, :parent => Puppet::Provider::N
         vol_export_policy = vol_export_attributes.child_get_string("policy")
       end
       # Get Auto size settings.
-      unless %w{offline restricted}.include?('offline')
+      unless vol_state == "offline"
         vol_auto_size = vol_autosize_info.child_get_string("mode")
       end
 


### PR DESCRIPTION
Puppet issue: https://github.com/puppetlabs/puppetlabs-netapp/issues/112

Couldn't fetch autosize property correctly in self instance. So autosize
property was going to set every time though it's value was provided the same in manifest.
Fixed by fetching autosize property when the volume state is not offline.