### PR TITLE
Fixed bug in acceptance test.

### DIFF
--- a/spec/acceptance/netapp_lun_spec.rb
+++ b/spec/acceptance/netapp_lun_spec.rb
@@ -4,6 +4,8 @@ describe 'lun' do
   it 'makes a lun' do
     pp=<<-EOS
 node 'vsim-01' {
+}
+node 'vserver-01' {
   netapp_volume { 'stuff':
     ensure       => 'present',
     autosize     => 'off',
@@ -12,9 +14,8 @@ node 'vsim-01' {
     junctionpath => 'false',
     snapreserve  => '5',
     state        => 'online',
+    aggregate    => 'aggr_new'
   }
-}
-node 'vserver-01' {
   netapp_lun { '/vol/stuff/lun1':
     ensure => 'present',
     size   => '4194304',
@@ -30,6 +31,8 @@ node 'vserver-01' {
   it 'delete a lun' do
     pp=<<-EOS
 node 'vsim-01' {
+}
+node 'vserver-01' {
   netapp_volume { 'stuff':
     ensure       => 'present',
     autosize     => 'off',
@@ -39,8 +42,6 @@ node 'vsim-01' {
     snapreserve  => '5',
     state        => 'online',
   }
-}
-node 'vserver-01' {
   netapp_lun { '/vol/stuff/lun1':
     ensure => 'absent',
     size   => '4194308',


### PR DESCRIPTION
Puppet issue: https://github.com/puppetlabs/puppetlabs-netapp/issues/112
    
Volume was going to be created on cluster, but "volume create" is a vserver
 command and mandatory property "aggregate" was missing to create volume.
    
Fixed by changing the node from cluster to vserver for volume creation and
"aggregate" property provided.