### PR TITLE
Modified provider file, added check if name-mapping-switch is null.

### DIFF
--- a/lib/puppet/provider/netapp_vserver/cmode.rb
+++ b/lib/puppet/provider/netapp_vserver/cmode.rb
@@ -46,10 +46,13 @@ Puppet::Type.type(:netapp_vserver).provide(:cmode, :parent => Puppet::Provider::
 
       # Name mapping switch
       namemappingswitch = []
-      namemappingswitch_info = vserver.child_get("name-mapping-switch").children_get()
-      namemappingswitch_info.each do |nmswitch|
-        namemappingswitch << nmswitch.content()
-      end unless namemappingswitch_info.nil?
+      namemappingswitch_infos = vserver.child_get("name-mapping-switch")
+      if namemappingswitch_infos != nil
+        namemappingswitch_info = namemappingswitch_infos.children_get()
+        namemappingswitch_info.each do |nmswitch|
+          namemappingswitch << nmswitch.content()
+        end unless namemappingswitch_info.nil?
+      end
       # Name server switch
       nameserverswitch = []
       nameserverswitch_info = vserver.child_get("name-server-switch").children_get()


### PR DESCRIPTION
Puppet issue: https://github.com/puppetlabs/puppetlabs-netapp/issues/105
    
If name-mapping-switch fetched as null in self.instances, puppet was
giving error as: undefined method `children_get' for nil:NilClass
    
Added check when name-mapping-switch is null.