### PR TITLE
Fixed bug in netapp_iscsi provider and acceptance test files.

### DIFF
--- a/lib/puppet/provider/netapp_iscsi/cmode.rb
+++ b/lib/puppet/provider/netapp_iscsi/cmode.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:netapp_iscsi).provide(:cmode, :parent => Puppet::Provider::Ne
           fail ArgumentError, "Cannot change #{property} after creation"
         end
       end
-      iscsimodify(*get_args)
+      iscsimodify(*get_args('modify'))
     end
   end
 
@@ -71,7 +71,7 @@ Puppet::Type.type(:netapp_iscsi).provide(:cmode, :parent => Puppet::Provider::Ne
   end
 
   def create
-    iscsicreate(*get_args)
+    iscsicreate(*get_args('create'))
     @property_hash.clear
   end
 
@@ -83,10 +83,12 @@ Puppet::Type.type(:netapp_iscsi).provide(:cmode, :parent => Puppet::Provider::Ne
     @property_hash[:ensure] == :present
   end
 
-  def get_args
+  def get_args(method)
     args = Array.new
     # Alias-name is only settable on create
-    args += ['alias-name', resource[:target_alias]] if resource[:target_alias]
+    if method == 'create'
+      args += ['alias-name', resource[:target_alias]] if resource[:target_alias]
+    end
     args
   end
 end

--- a/spec/acceptance/netapp_iscsi_spec.rb
+++ b/spec/acceptance/netapp_iscsi_spec.rb
@@ -13,8 +13,8 @@ node 'vsim-01' {
 }
 node 'vserver-01' {  
 }
-node 'vserver-iscsi' {  
-  netapp_iscsi { 'vserveriscsi':
+node 'vserver-iscsi' {
+  netapp_iscsi { 'vserver-iscsi':
     ensure       => 'present',
     state        => 'on',
     target_alias => 'vserver-iscsi',
@@ -33,9 +33,28 @@ node 'vsim-01' {
 node 'vserver-01' {
 }
 node 'vserver-iscsi' {
-  netapp_iscsi { 'vserveriscsi':
+  netapp_iscsi { 'vserver-iscsi':
     ensure       => 'present',
     state        => 'off',
+    target_alias => 'vserver-iscsi',
+  }
+}
+    EOS
+    make_site_pp(pp)
+    run_device(:allow_changes => true)
+    run_device(:allow_changes => false)
+  end
+
+  it 'start a vserveriscsi' do
+    pp=<<-EOS
+node 'vsim-01' {
+}
+node 'vserver-01' {
+}
+node 'vserver-iscsi' {
+  netapp_iscsi { 'vserver-iscsi':
+    ensure       => 'present',
+    state        => 'on',
     target_alias => 'vserver-iscsi',
   }
 }
@@ -52,7 +71,7 @@ node 'vsim-01' {
 node 'vserver-01' {
 }
 node 'vserver-iscsi' {
-  netapp_iscsi { 'vserveriscsi':
+  netapp_iscsi { 'vserver-iscsi':
     ensure       => 'absent',
     state        => 'off',
     target_alias => 'vserver-iscsi',


### PR DESCRIPTION
Puppet issue: https://github.com/puppetlabs/puppetlabs-netapp/issues/110
    
iscsi-service-modify doesn't take "alias-name" as input though alias-name was
provided to this api and getting error.
iscsi service will be deleted through puppet when its state is "on", otherwise was giving error
as: Executing api call iscsi-service-stop failed: "Service, adapter, or operation not started"

Fixed by not providing alias-name to iscsi-service-modify api in provider file.
Added "start vserveriscsi" test before deletion in acceptance test.