### PR TITLE
Use the Minimum Autosize property as size property when autogrow is set to grow

### DIFF
--- a/lib/puppet/provider/netapp_volume/cmode.rb
+++ b/lib/puppet/provider/netapp_volume/cmode.rb
@@ -155,6 +155,10 @@ Puppet::Type.type(:netapp_volume).provide(:cmode, :parent => Puppet::Provider::N
       # Get Auto size settings.
       unless vol_state == "offline"
         vol_auto_size = vol_autosize_info.child_get_string("mode")
+        # use the Minimum Autosize as size when autgrow is enabled, otherwise the autogrow function will not work properly.
+        if vol_auto_size == 'grow'
+          vol_size_bytes = vol_autosize_info.child_get_int("minimum-size")
+        end
       end
 
       # Get junction path


### PR DESCRIPTION
There is an issue with autosize set to grow and the size property on a volume.
When a volume is growing due to autosize then this new size is compared with the size defined in puppet. As a result puppet will revert the size to the defined size and the netapp will resize it again.

If autosize is set to grow the minimum size is set to the initial size, so this property can be used to compare the size property.