### PR TITLE
Fixed bug to modify disklimit, softdisklimit and threshold value correctly.

### DIFF
--- a/lib/puppet/provider/netapp_quota/cmode.rb
+++ b/lib/puppet/provider/netapp_quota/cmode.rb
@@ -40,10 +40,10 @@ Puppet::Type.type(:netapp_quota).provide(:cmode, :parent => Puppet::Provider::Ne
       end
 
       # according to na_quota(5) entries can span over multiple lines
-      quota_hash[:disklimit] = size_in_byte(quota_entry.child_get_string('disk-limit')) unless quota_entry.child_get_string('disk-limit').nil? or quota_entry.child_get_string('disk-limit') == '-'
+      quota_hash[:disklimit] = size_in_byte(quota_entry.child_get_string('disk-limit', 'K')) unless quota_entry.child_get_string('disk-limit').nil? or quota_entry.child_get_string('disk-limit') == '-'
       quota_hash[:filelimit] = size_in_byte(quota_entry.child_get_string('file-limit')) unless quota_entry.child_get_string('file-limit').nil? or quota_entry.child_get_string('file-limit') == '-'
-      quota_hash[:threshold] = size_in_byte(quota_entry.child_get_string('threshold')) unless quota_entry.child_get_string('threshold').nil? or quota_entry.child_get_string('threshold') == '-'
-      quota_hash[:softdisklimit] = size_in_byte(quota_entry.child_get_string('soft-disk-limit')) unless quota_entry.child_get_string('soft-disk-limit').nil? or quota_entry.child_get_string('soft-disk-limit') == '-'
+      quota_hash[:threshold] = size_in_byte(quota_entry.child_get_string('threshold', 'K')) unless quota_entry.child_get_string('threshold').nil? or quota_entry.child_get_string('threshold') == '-'
+      quota_hash[:softdisklimit] = size_in_byte(quota_entry.child_get_string('soft-disk-limit', 'K')) unless quota_entry.child_get_string('soft-disk-limit').nil? or quota_entry.child_get_string('soft-disk-limit') == '-'
       quota_hash[:softfilelimit] = size_in_byte(quota_entry.child_get_string('soft-file-limit')) unless quota_entry.child_get_string('soft-file-limit').nil? or quota_entry.child_get_string('soft-file-limit') == '-'
 
       instances << new(quota_hash)


### PR DESCRIPTION
Issue link:https://github.com/puppetlabs/puppetlabs-netapp/issues/130

disklimit, softdisklimit and threshold were going to be modified in every
puppet run though the value was provided same in manifest.

Fixed by fetching the value correctly in self.instances.